### PR TITLE
Support for MapAsserter.shouldNotHaveKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Map<String, Object> stringObjectMap = new HashMap<String, Object>() {{
 
 it(stringObjectMap)
         .shouldHaveKey("key1").withValue(value1)
-        .shouldHaveKey("key2").withValue(value2);
+        .shouldHaveKey("key2").withValue(value2)
+        .shouldNotHaveKey("unwantedKey");
 ```
 
 ## Exceptions

--- a/src/main/java/name/mlnkrishnan/shouldJ/asserter/MapAsserter.java
+++ b/src/main/java/name/mlnkrishnan/shouldJ/asserter/MapAsserter.java
@@ -22,6 +22,15 @@ public class MapAsserter<K, V> extends ObjectAsserter<Map<K, V>> {
         return new MapValueAsserter<K, V>(expectedKey, actual);
     }
 
+    public MapAsserter<K, V> shouldNotHaveKey(K notExpectedKey) {
+        if(actual == null)
+            throw new ActualValueIsNull();
+        if(actual.containsKey(notExpectedKey))
+            throw new ExpectationMismatch(String.format("found unwanted key <%s> in map", notExpectedKey));
+
+        return new MapAsserter<K, V>(actual);
+    }
+
     public class MapValueAsserter<K, V> extends MapAsserter<K,V>{
         final private K key;
 

--- a/src/test/java/name/mlnkrishnan/shouldJ/asserter/MapAsserterTest.java
+++ b/src/test/java/name/mlnkrishnan/shouldJ/asserter/MapAsserterTest.java
@@ -69,4 +69,31 @@ public class MapAsserterTest {
             assertEquals(String.format("expected key <%s> to have value <%s>, but the value was <%s>", "key2", notInMap, value2), e.getMessage());
         }
     }
+
+    @Test
+    public void shouldNotHaveKey_Pass() {
+        Map<String, Object> stringObjectMap = new HashMap<String, Object>();
+        stringObjectMap.put("key1", new Object());
+
+        it(stringObjectMap)
+                .shouldHaveKey("key1")
+                .shouldNotHaveKey("nonExistantKey1")
+                .shouldNotHaveKey("nonExistantKey2");
+    }
+
+    @Test
+    public void shouldNotHaveKey_Fail() {
+        Map<String, Object> stringObjectMap = new HashMap<String, Object>();
+        stringObjectMap.put("key1", new Object());
+        stringObjectMap.put("key2", new Object());
+
+        try {
+            it(stringObjectMap)
+                    .shouldHaveKey("key1")
+                    .shouldNotHaveKey("key2");
+            fail();
+        } catch (Throwable e) {
+            assertEquals(String.format("found unwanted key <%s> in map", "key2"), e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Currently `MapAsserter` has a `shouldHaveKey`, need a corresponding complementary assertion.
