### PR TITLE
Issue #5

### DIFF
--- a/src/main/java/name/mlnkrishnan/shouldJ/asserter/ArrayAsserter.java
+++ b/src/main/java/name/mlnkrishnan/shouldJ/asserter/ArrayAsserter.java
@@ -38,6 +38,15 @@ public class ArrayAsserter<T> extends ObjectAsserter<Object> {
         return this;
     }
 
+    public ArrayAsserter<T> shouldBe(T[] array) {
+        assertNotNull();
+
+        if (! Arrays.deepEquals(array, actual))
+            throw new ExpectationMismatch(String.format("expected array <%s> to be <%s>", Arrays.toString(actual), Arrays.toString(array)));
+
+        return this;
+    }
+
     private void assertNotNull() {
         if (actual == null)
             throw new ActualValueIsNull();

--- a/src/main/java/name/mlnkrishnan/shouldJ/asserter/ObjectAsserter.java
+++ b/src/main/java/name/mlnkrishnan/shouldJ/asserter/ObjectAsserter.java
@@ -4,6 +4,8 @@ import name.mlnkrishnan.shouldJ.failure.ActualValueIsNull;
 import name.mlnkrishnan.shouldJ.failure.ExpectationMismatch;
 import org.hamcrest.Matcher;
 
+import java.lang.reflect.Array;
+
 public class ObjectAsserter<T> {
     final protected T actual;
 
@@ -12,6 +14,13 @@ public class ObjectAsserter<T> {
     }
 
     public ObjectAsserter<T> shouldBe(T expected) {
+
+        if (isArray(expected) && isArray(actual)) {
+            if (! lengthsEqual(expected) || ! elementsEqual(expected))
+                throw new ExpectationMismatch(String.format("expected array <%s> to be <%s>", toArrayString(actual), toArrayString(expected)));
+            return this;
+        }
+
         if(!actual.equals(expected))
            throw new ExpectationMismatch(String.format("expected <%s>, but got <%s>", expected, actual));
         return this;
@@ -50,5 +59,42 @@ public class ObjectAsserter<T> {
             throw new ExpectationMismatch(matcher.toString() + ", but was <" + actual + ">");
         }
         return this;
+    }
+
+    private boolean isArray(Object obj) {
+        return obj.getClass().isArray();
+    }
+
+    private boolean lengthsEqual(Object expected) {
+        return Array.getLength(expected) == Array.getLength(actual);
+    }
+
+    private boolean elementsEqual(Object expected) {
+        for(int i = 0; i < Array.getLength(expected); ++i) {
+            if (! Array.get(expected, i).equals(Array.get(actual, i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String toArrayString(Object expected) {
+        String begin = "[";
+        String delimiter = ",";
+        String end = "]";
+
+        StringBuilder arrayString = new StringBuilder(begin);
+        boolean separate = false;
+        for(int i = 0; i < Array.getLength(expected); ++i) {
+            if (separate) {
+                arrayString.append(delimiter);
+            }
+            arrayString.append(Array.get(expected, i));
+            separate = true;
+        }
+
+        arrayString.append(end);
+
+        return arrayString.toString();
     }
 }

--- a/src/test/java/name/mlnkrishnan/shouldJ/asserter/ArrayAsserterTest.java
+++ b/src/test/java/name/mlnkrishnan/shouldJ/asserter/ArrayAsserterTest.java
@@ -89,4 +89,22 @@ public class ArrayAsserterTest {
         expectedException.expectMessage("expected <obj1> at position <1> but was at <0>");
         it(array).shouldHave("obj1").at(1);
     }
+
+    @Test
+    public void shouldBe_Pass() {
+        String[] array = {"obj1", "obj2"};
+        String[] expected = {"obj1", "obj2"};
+
+        it(array).shouldBe(expected);
+    }
+
+    @Test
+    public void shouldBe_Fail() {
+        String[] array = {"obj1", "obj2"};
+        String[] expected = {"obj1", "obj2", "obj3"};
+
+        expectedException.expect(ExpectationMismatch.class);
+        expectedException.expectMessage("expected array <[obj1, obj2]> to be <[obj1, obj2, obj3]>");
+        it(array).shouldBe(expected);
+    }
 }

--- a/src/test/java/name/mlnkrishnan/shouldJ/asserter/ObjectAsserterTest.java
+++ b/src/test/java/name/mlnkrishnan/shouldJ/asserter/ObjectAsserterTest.java
@@ -1,7 +1,10 @@
 package name.mlnkrishnan.shouldJ.asserter;
 
+import name.mlnkrishnan.shouldJ.failure.ExpectationMismatch;
 import org.hamcrest.core.Is;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
@@ -9,6 +12,9 @@ import static name.mlnkrishnan.shouldJ.ShouldJ.it;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ObjectAsserterTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void shouldBe_Pass() {
@@ -103,6 +109,26 @@ public class ObjectAsserterTest {
             assertEquals("is \"456\", but was <123>", e.getMessage());
         }
     }
+
+
+    @Test
+    public void shouldBe_Pass_For_Primitive_Arrays() {
+        int[] array = {10, 15};
+        int[] expected = {10, 15};
+
+        it(array).shouldBe(expected);
+    }
+
+    @Test
+    public void shouldBe_Fail_For_Primitive_Arrays() {
+        int[] array = {10, 15};
+        int[] expected = {10, 15, 20};
+
+        expectedException.expect(ExpectationMismatch.class);
+        expectedException.expectMessage("expected array <[10,15]> to be <[10,15,20]>");
+        it(array).shouldBe(expected);
+    }
+
 
     class DummyType {
     }


### PR DESCRIPTION
Fix for #5 

For primitive arrays, the checks need to be in ObjectAsserter since primitive arrays can't be type-casted to their boxed types.  

The code is very similar to how hamcrest is handling this.